### PR TITLE
Name fix, couple of markdown changes due to markdownlinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # pptb-docs-web
-Documentation for Power Platform Tool Box
+
+Documentation for Power Platform ToolBox

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,11 +9,11 @@ import '@/styles/tailwind.css'
 
 export const metadata: Metadata = {
   title: {
-    template: '%s - Power Platform Tool Box',
-    default: 'Power Platform Tool Box - Documentation',
+    template: '%s - Power Platform ToolBox',
+    default: 'Power Platform ToolBox - Documentation',
   },
   description:
-    'Documentation for Power Platform Tool Box - The modern toolbox for Power Platform, built for speed, simplicity and security.',
+    'Documentation for Power Platform ToolBox - The modern toolbox for Power Platform, built for speed, simplicity and security.',
 }
 
 export default async function RootLayout({

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -118,7 +118,7 @@ function SmallPrint() {
   return (
     <div className="flex flex-col items-center justify-between gap-5 border-t border-zinc-900/5 pt-8 sm:flex-row dark:border-white/5">
       <p className="text-xs text-zinc-600 dark:text-zinc-400">
-        &copy; Copyright {new Date().getFullYear()} Power Platform Tool Box. All
+        &copy; Copyright {new Date().getFullYear()} Power Platform ToolBox. All
         rights reserved.
       </p>
       <div className="flex gap-4">

--- a/src/components/Guides.tsx
+++ b/src/components/Guides.tsx
@@ -5,18 +5,18 @@ const guides = [
   {
     href: '/quickstart',
     name: 'Quick Start',
-    description: 'Get up and running with Power Platform Tool Box in minutes.',
+    description: 'Get up and running with Power Platform ToolBox in minutes.',
   },
   {
     href: '/tool-development',
     name: 'Tool Development',
     description:
-      'Build tools for Power Platform Tool Box with our comprehensive API.',
+      'Build tools for Power Platform ToolBox with our comprehensive API.',
   },
   {
     href: '/toolbox-development',
     name: 'ToolBox Development',
-    description: 'Contribute to the Power Platform Tool Box platform itself.',
+    description: 'Contribute to the Power Platform ToolBox platform itself.',
   },
   {
     href: '/contributing',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,7 +77,7 @@ export const Header = forwardRef<
         <CloseButton as={Link} href="/" aria-label="Home">
           <Image
             src="../images/app-icon.svg"
-            alt="Power Platform Tool Box"
+            alt="Power Platform ToolBox"
             className="h-6"
             width="24"
             height="24"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,10 +4,10 @@ import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
+import { EditLink } from '@/components/EditLink'
 import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
 import { Navigation } from '@/components/Navigation'
-import { EditLink } from '@/components/EditLink'
 import { SectionProvider, type Section } from '@/components/SectionProvider'
 import Image from 'next/image'
 
@@ -32,7 +32,7 @@ export function Layout({
               <Link href="/" aria-label="Home">
                 <Image
                   src="/images/app-icon.svg"
-                  alt="Power Platform Tool Box"
+                  alt="Power Platform ToolBox"
                   className="h-10"
                   width="40"
                   height="40"


### PR DESCRIPTION
Some more name fixes that I missed, couple of markdown changes due to prettier/markdownlinter chirping at me.

The editlink change is also due to linter - Alphabetized it.